### PR TITLE
Various fixes / minor changes

### DIFF
--- a/bcdl.go
+++ b/bcdl.go
@@ -28,7 +28,7 @@ import (
 func sanitize(path string) string {
 	//meant to mimic whatever bandcamp uses
 	//probably not perfect
-	return regexp.MustCompile(`[=,:<>[\]]+|[-,\.]+$`).ReplaceAllString(
+	return regexp.MustCompile(`^[-\.]+|[=,:<>[\]]+|[-\.]+$`).ReplaceAllString(
 		regexp.MustCompile(`[%*?|,/\\]`).ReplaceAllString(path, "-"),
 		"")
 }

--- a/bcdl.go
+++ b/bcdl.go
@@ -25,6 +25,14 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func sanitize(path string) string {
+	//meant to behave equivalently to whatever bandcamp uses
+	//probably not perfect
+	return regexp.MustCompile(`[=,<>[\]]+|-+$`).ReplaceAllString(
+		regexp.MustCompile(`[%*|,/\\]`).ReplaceAllString(path, "-"),
+		"")
+}
+
 func getDescription(releaseFolder string) {
 	description := releasePageHTML.Find("meta", "name", "description").Attrs()["content"]
 
@@ -514,8 +522,8 @@ func printReleaseName(releaseTitle string, releaseArtist string) {
 
 func findReleaseInFolder(releaseTitle string, releaseArtist string, searchFolder string) string {
 	// Bandcamp downloads have the standard format of ArtistName - ReleaseTitle
-	folderPath := fmt.Sprintf("%s - %s", releaseArtist, releaseTitle)
 
+	folderPath := sanitize(fmt.Sprintf("%s - %s", releaseArtist, releaseTitle))
 	// Get a list of all files and subdirectories in the specified folder
 	files, err := filepath.Glob(filepath.Join(searchFolder, "*"))
 	if err != nil {

--- a/bcdl.go
+++ b/bcdl.go
@@ -423,14 +423,29 @@ func artistPageLinkGen(releaseLink string) {
 		log.Fatal(err)
 	}
 
-	// Gets all links in the middle box
-	for _, boxLink := range releasePageHTML.Find("div", "class", "leftMiddleColumns").FindAll("a") {
+	// Gets all links in the music grid
+	musicGrid :=releasePageHTML.Find("ol","id","music-grid")
+
+	for _, boxLink := range musicGrid.FindAll("a") {
 		rel, err := u.Parse(boxLink.Attrs()["href"])
 		if err != nil {
 			log.Fatal(err)
 		}
 		pageLinks = append(pageLinks, rel.String())
 	}
+
+	// Check for javascript-rendered entries
+	j := musicGrid.Attrs()["data-client-items"]
+	var items []map[string]string
+	json.Unmarshal([]byte(j), &items)
+	for _, item := range items {
+		rel, err := u.Parse(item["page_url"])
+		if err != nil {
+		log.Fatal(err)
+		}
+		pageLinks = append(pageLinks, rel.String())
+	}
+	
 
 	// Removes duplicate values from pages that have featured releases
 	pageLinks = removeDuplicateValues(pageLinks)

--- a/bcdl.go
+++ b/bcdl.go
@@ -26,10 +26,10 @@ import (
 )
 
 func sanitize(path string) string {
-	//meant to behave equivalently to whatever bandcamp uses
+	//meant to mimic whatever bandcamp uses
 	//probably not perfect
-	return regexp.MustCompile(`[=,<>[\]]+|-+$`).ReplaceAllString(
-		regexp.MustCompile(`[%*|,/\\]`).ReplaceAllString(path, "-"),
+	return regexp.MustCompile(`[=,:<>[\]]+|[-,\.]+$`).ReplaceAllString(
+		regexp.MustCompile(`[%*?|,/\\]`).ReplaceAllString(path, "-"),
 		"")
 }
 
@@ -601,7 +601,7 @@ func userPageLinkGen(releaseLink string) {
 		collectionSummary = getCollectionSummary(true)
 
 		for _, k := range gjson.Get(collectionSummary, "items").Array() {
-			if !preDownloadCheck(gjson.Get(k.Raw, "album_title").String(),
+			if !preDownloadCheck(gjson.Get(k.Raw, "item_title").String(),
 				gjson.Get(k.Raw, "band_name").String()){
 					continue
 				}

--- a/bcdl.go
+++ b/bcdl.go
@@ -204,8 +204,14 @@ func getPopplersFromSelectDownloadPage(selectDownloadURL string) string {
 	// Change some of the url parameters because email download links and collection download links are different.
 	if urlQuerys.Get("from") == "collection" {
 		selectDownloadPageHTML, _ := soup.Get(selectDownloadURL)
-		urlQuerys.Set("id", regexp.MustCompile(`id=(\d*)&`).FindStringSubmatch(selectDownloadPageHTML)[1])
-		urlQuerys.Set("type", regexp.MustCompile(`\/download\/(album|track)\?`).FindStringSubmatch(selectDownloadPageHTML)[1])
+		id:=regexp.MustCompile(`id=(\d*)&`).FindStringSubmatch(selectDownloadPageHTML)
+		t:=regexp.MustCompile(`\/download\/(album|track)\?`).FindStringSubmatch(selectDownloadPageHTML)
+		if id == nil || t == nil {
+			color.Red("### Download not available")
+			return ""
+		}
+		urlQuerys.Set("id", id[1])
+		urlQuerys.Set("type", t[1])
 	}
 
 	params := url.Values{}


### PR DESCRIPTION
fixes #17 

I don't know why bandcamp does this. Alll the data is still in the original request but as an array of json objects in an html attribute,

Applies to most (not all) artists with >16 releases. Started some time in 2024.